### PR TITLE
Updated the Sign up page where there is content issue - like sign up page and sign in page had same content and sign up page linked with sign up page not with sign in page

### DIFF
--- a/task-manager-ui/src/components/Signup.jsx
+++ b/task-manager-ui/src/components/Signup.jsx
@@ -30,7 +30,7 @@ export default function Register() {
       <div className="w-full bg-white rounded-lg md:mt-0 sm:max-w-md xl:p-0 shadow-3xl">
         <div className="p-6 space-y-4 md:space-y-6 sm:p-8">
           <h1 className="text-xl font-bold leading-tight tracking-tight text-gray-900 md:text-2xl">
-            Sign in to your account
+            Create your account
           </h1>
           <form
             className="space-y-4 md:space-y-6"
@@ -93,12 +93,12 @@ export default function Register() {
               Sign Up
             </button>
             <p className="text-sm font-light text-gray-500">
-              Don't have an account yet?{" "}
+              Already have an account? {" "}
               <Link
-                to="/signup"
+                to="/Login"
                 className="font-medium text-primary-600 hover:underline"
               >
-                Sign up
+                Sign in
               </Link>
             </p>
           </form>


### PR DESCRIPTION
Noticed few issue in sign up page that
Before making changes:
1. The header was "Sign in to your account
2. Below the sign up button, there is a text "Don't have an account already? Sign up
![image](https://github.com/user-attachments/assets/cf1765bf-219d-43b8-95ee-6f72215c93e2)

Changes Made in sign up page:
1. Changed the header to "Create your account"
2. Changes the content below sign up button to "Already have an account? Sign In" and linked this "Sign In" text to Sign In page
![image](https://github.com/user-attachments/assets/393ce81d-829c-42cc-a647-ca48f24f1a67)

